### PR TITLE
Remove 'ViaGroup' references from PIM role assignment change detectio…

### DIFF
--- a/Get-PIMUsers.ps1
+++ b/Get-PIMUsers.ps1
@@ -786,7 +786,6 @@ function Compare-PIMExports {
                     RoleName = $record.RoleName
                     AssignmentType = $record.AssignmentType
                     UserType = $record.UserType
-                    ViaGroup = $record.ViaGroup
                     PreviousValue = "N/A"
                     CurrentValue = "$($record.AssignmentType)"
                     Description = "Nieuwe rol toewijzing gedetecteerd"
@@ -809,7 +808,6 @@ function Compare-PIMExports {
                     RoleName = $record.RoleName
                     AssignmentType = $record.AssignmentType
                     UserType = $record.UserType
-                    ViaGroup = $record.ViaGroup
                     PreviousValue = "$($record.AssignmentType)"
                     CurrentValue = "N/A"
                     Description = "Rol toewijzing verwijderd"
@@ -840,7 +838,6 @@ function Compare-PIMExports {
                             RoleName = $current.RoleName
                             AssignmentType = $current.AssignmentType
                             UserType = $current.UserType
-                            ViaGroup = $current.ViaGroup
                             PreviousValue = $previous.AssignmentType
                             CurrentValue = $current.AssignmentType
                             Description = "Assignment type structureel gewijzigd van $($previous.AssignmentType) naar $($current.AssignmentType)"
@@ -848,26 +845,6 @@ function Compare-PIMExports {
                         }
                         $changes += $change
                     }
-                }
-                
-                # Check voor wijzigingen in groepstoewijzing
-                if ($current.ViaGroup -ne $previous.ViaGroup) {
-                    $change = [PSCustomObject]@{
-                        ChangeType = "MODIFIED"
-                        Timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
-                        Customer = $current.Customer
-                        DisplayName = $current.DisplayName
-                        UserPrincipalName = $current.UserPrincipalName
-                        RoleName = $current.RoleName
-                        AssignmentType = $current.AssignmentType
-                        UserType = $current.UserType
-                        ViaGroup = $current.ViaGroup
-                        PreviousValue = $previous.ViaGroup
-                        CurrentValue = $current.ViaGroup
-                        Description = "Groepstoewijzing gewijzigd van '$($previous.ViaGroup)' naar '$($current.ViaGroup)'"
-                        PrincipalId = $current.PrincipalId
-                    }
-                    $changes += $change
                 }
             }
         }


### PR DESCRIPTION
This pull request simplifies the `Compare-PIMExports` function in `Get-PIMUsers.ps1` by removing all logic and output related to the `ViaGroup` property. This streamlines the change tracking and focuses the comparison on assignment type changes only.

**Removal of ViaGroup-related logic:**

* Eliminated the inclusion of the `ViaGroup` property in the output objects for new assignments, removals, and assignment type changes. [[1]](diffhunk://#diff-1c588e3cfd4e3f817e67bffd7df8dce7e8022a210768af82aee57ea10473665dL789) [[2]](diffhunk://#diff-1c588e3cfd4e3f817e67bffd7df8dce7e8022a210768af82aee57ea10473665dL812) [[3]](diffhunk://#diff-1c588e3cfd4e3f817e67bffd7df8dce7e8022a210768af82aee57ea10473665dL843)
* Removed the section that checked for changes in group assignment (`ViaGroup`) and reported them as modifications.